### PR TITLE
Updated README.md to reflect actual package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Take your MIDI file, drop it into your favorite DAW and [make a beat!](https://c
 
 ## Installation
 
-    $ pip install chord2midi
+    $ pip install chords2midi
 
 ## Usage
 


### PR DESCRIPTION
I noticed that the pip package name is "chord**s**2midi", not "chord2midi", so I updated the README.